### PR TITLE
fix(layout): remove Firefox UA that causes chat pane to overlap contact list

### DIFF
--- a/app/agents.json
+++ b/app/agents.json
@@ -1,6 +1,5 @@
 {
     "userAgents": [
-        "Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
     ]
 }


### PR DESCRIPTION
> **Note from submitter:** My LLM submitted this and I will review this too and then change this message. Please don't be angry — a human (me) will review before merge.

## Summary
- The random User-Agent picker in `app/main.js` selects from `app/agents.json` on every launch.
- The **Firefox/Linux UA** (`Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0`) causes WhatsApp Web to serve a layout where the **chat/message pane overlaps the contact list**.
- The Chrome/macOS UA renders the correct two-pane layout.
- Fix: remove the Firefox entry from `agents.json` so the random pick always lands on the working UA. Minimal one-line diff.

## Root cause
WhatsApp Web serves different layouts/feature flags per UA. With the Firefox UA, the panes (chat list + message view) overlap instead of sitting side-by-side. This reproduces on roughly half of launches (whenever the random index lands on the Firefox entry).

## Verification
- Ran the app from source (Electron 17.4.11) reusing the existing session (`~/.config/whatsapp-desktop`) — **no QR re-login**.
- With the Firefox UA: overlap reproduced.
- With the Chrome/macOS UA (after this change): layout correct, messages up to date, still logged in.

## Changes
- `app/agents.json`: removed the Firefox/Linux UA entry (1 line deleted).

## Notes
- `app/main.js` was left unchanged; it still picks randomly, but with one entry it always picks the working UA.
- Alternatively the random pick could be removed entirely in `main.js`, but this PR keeps the diff to one line.